### PR TITLE
Configure Titan service credentials for multi-host view

### DIFF
--- a/src/components/ServicesMultiHost/ServicesMultiHost.jsx
+++ b/src/components/ServicesMultiHost/ServicesMultiHost.jsx
@@ -10,7 +10,18 @@ import api from "../../utils/api";
  */
 
 const PROTOCOL = "http";
-const TITAN_SERVICES_PATH = "/services";
+const TITAN_SERVICES_PATH = "/api/v1/servicesmngt/services";
+const env =
+  typeof import.meta !== "undefined" && import.meta?.env
+    ? import.meta.env
+    : {};
+const TITAN_USERNAME = env.VITE_TITAN_USERNAME || "Operator";
+const TITAN_PASSWORD = env.VITE_TITAN_PASSWORD || "titan";
+const TITAN_REQUEST_OPTIONS = {
+  path: TITAN_SERVICES_PATH,
+  username: TITAN_USERNAME,
+  password: TITAN_PASSWORD,
+};
 
 // Hosts proporcionados
 const HOSTS = [
@@ -244,7 +255,7 @@ function describeError(error) {
       else {
         try {
           detail = JSON.stringify(data);
-        } catch (e) {
+        } catch {
           detail = String(data);
         }
       }
@@ -255,7 +266,7 @@ function describeError(error) {
   if (error?.message) return error.message;
   try {
     return JSON.stringify(error);
-  } catch (e) {
+  } catch {
     return String(error);
   }
 }
@@ -268,7 +279,7 @@ function describeTitanEntryError(entry) {
     if (entry.error?.message) return entry.error.message;
     try {
       return JSON.stringify(entry.error);
-    } catch (e) {
+    } catch {
       return String(entry.error);
     }
   }
@@ -422,7 +433,7 @@ export default function ServicesMultiHost() {
     try {
       const multiResponse = await api.getTitanServicesMulti(
         hostIps,
-        TITAN_SERVICES_PATH
+        TITAN_REQUEST_OPTIONS
       );
       const entries = normalizeTitanMultiResponse(multiResponse);
       const processed = processTitanEntries(entries, hostMap);
@@ -434,7 +445,7 @@ export default function ServicesMultiHost() {
       if (missingHosts.length > 0) {
         const settled = await Promise.allSettled(
           missingHosts.map((ip) =>
-            api.getTitanServices(ip, TITAN_SERVICES_PATH)
+            api.getTitanServices(ip, TITAN_REQUEST_OPTIONS)
           )
         );
 
@@ -456,7 +467,7 @@ export default function ServicesMultiHost() {
 
       const settled = await Promise.allSettled(
         HOSTS.map((host) =>
-          api.getTitanServices(host.ip, TITAN_SERVICES_PATH)
+          api.getTitanServices(host.ip, TITAN_REQUEST_OPTIONS)
         )
       );
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -12,6 +12,29 @@ function onRefreshed() {
     queue.length = 0;
 }
 
+const env = typeof import.meta !== "undefined" ? import.meta.env ?? {} : {};
+
+const DEFAULT_TITAN_OPTIONS = Object.freeze({
+    path: env.VITE_TITAN_SERVICES_PATH || "/api/v1/servicesmngt/services",
+    username: env.VITE_TITAN_USERNAME || "Operator",
+    password: env.VITE_TITAN_PASSWORD || "titan",
+});
+
+function normalizeTitanOptions(pathOrOptions) {
+    if (typeof pathOrOptions === "string") {
+        return { path: pathOrOptions };
+    }
+    if (pathOrOptions && typeof pathOrOptions === "object") {
+        const { path, username, password } = pathOrOptions;
+        const normalized = {};
+        if (path !== undefined) normalized.path = path;
+        if (username !== undefined) normalized.username = username;
+        if (password !== undefined) normalized.password = password;
+        return normalized;
+    }
+    return {};
+}
+
 class Api {
     constructor(url) {
         this._axios = axios.create({ baseURL: url, withCredentials: true });
@@ -281,15 +304,31 @@ class Api {
     }
 
     // ====== TITANS ======
-    getTitanServices(host, path = "/services") {
+    getTitanServices(host, pathOrOptions = undefined) {
+        const options = normalizeTitanOptions(pathOrOptions);
+        const path = options.path ?? DEFAULT_TITAN_OPTIONS.path;
+        const username = options.username ?? DEFAULT_TITAN_OPTIONS.username;
+        const password = options.password ?? DEFAULT_TITAN_OPTIONS.password;
+
+        const params = { host, path };
+        if (username) params.username = username;
+        if (password) params.password = password;
+
         return this._axios
             .get(`/titans/services`, {
-                params: { host, path },
+                params,
             })
             .then((r) => r.data);
     }
-    getTitanServicesMulti(hosts, path = "/services") {
+    getTitanServicesMulti(hosts, pathOrOptions = undefined) {
+        const options = normalizeTitanOptions(pathOrOptions);
+        const path = options.path ?? DEFAULT_TITAN_OPTIONS.path;
+        const username = options.username ?? DEFAULT_TITAN_OPTIONS.username;
+        const password = options.password ?? DEFAULT_TITAN_OPTIONS.password;
+
         const params = { path };
+        if (username) params.username = username;
+        if (password) params.password = password;
         if (Array.isArray(hosts)) {
             params.hosts = hosts.join(",");
         } else if (typeof hosts === "string") {


### PR DESCRIPTION
## Summary
- update the Titan services client to use the new /api/v1/servicesmngt/services path and default Operator/titan credentials (overridable via env vars)
- ensure the multi-host frontend view requests Titan data with the configured path and credentials

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e32526d75083218197561cfeb6d9b8