### PR TITLE
Restrict channel diagram editing to authenticated users

### DIFF
--- a/src/pages/ChannelDiagram/ChannelDiagram.css
+++ b/src/pages/ChannelDiagram/ChannelDiagram.css
@@ -42,6 +42,22 @@
     box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
 }
 
+.diagram-readonly-banner {
+    position: absolute;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(30, 41, 59, 0.92);
+    color: #f8fafc;
+    padding: 0.6rem 1.25rem;
+    border-radius: 9999px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.25);
+    pointer-events: none;
+    z-index: 10;
+}
+
 .chd__sidebar {
     width: 320px;
     display: flex;

--- a/src/pages/ChannelDiagram/RouterNode.jsx
+++ b/src/pages/ChannelDiagram/RouterNode.jsx
@@ -1,6 +1,7 @@
 // src/pages/ChannelDiagram/RouterNode.jsx
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useContext, useRef, useState } from "react";
 import { Handle, Position, useReactFlow } from "@xyflow/react";
+import { UserContext } from "../../components/context/UserContext";
 
 const styles = {
   box: {
@@ -30,17 +31,20 @@ const vSlots = [6, 17, 28, 39, 50, 61, 72, 83, 94]; // 9 puertos verticales
 
 export default function RouterNode({ id, data }) {
   const rf = useReactFlow();
+  const { isAuth } = useContext(UserContext);
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(() => data?.label ?? "Router");
   const inputRef = useRef(null);
 
   const startEdit = useCallback((e) => {
+    if (!isAuth) return;
     e.stopPropagation();
     setValue(String(data?.label ?? "Router"));
     setEditing(true);
-  }, [data?.label]);
+  }, [data?.label, isAuth]);
 
   const commit = useCallback(() => {
+    if (!isAuth) return;
     setEditing(false);
     rf.setNodes((nds) =>
       nds.map((n) =>
@@ -49,7 +53,7 @@ export default function RouterNode({ id, data }) {
     );
     // que el autosave arriba escuche
     window.dispatchEvent(new Event("flow:save"));
-  }, [id, value, rf]);
+  }, [id, value, rf, isAuth]);
 
   const onKeyDown = useCallback((e) => {
     if (e.key === "Enter") commit();
@@ -62,7 +66,11 @@ export default function RouterNode({ id, data }) {
   return (
     <div style={styles.box} title={data?.tooltip || data?.label || "Router"}>
       {!editing ? (
-        <div style={styles.title} onDoubleClick={startEdit} title="Doble click para editar">
+        <div
+          style={{ ...styles.title, cursor: isAuth ? "text" : "default" }}
+          onDoubleClick={startEdit}
+          title={isAuth ? "Doble click para editar" : "Solo lectura"}
+        >
           {data?.label ?? "Router"}
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- disable drag, drop, and label editing on channel diagrams when the session is not authenticated and show a read-only banner
- ensure router and edge labels respect authentication state and persist label position changes through the autosave flow
- add styling for the read-only banner overlay

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e18f34788321bb0d85d6e93f30c7