### PR TITLE
Add node equipment sidebar to ChannelDiagram

### DIFF
--- a/src/pages/ChannelDiagram/ChannelDiagram.css
+++ b/src/pages/ChannelDiagram/ChannelDiagram.css
@@ -58,6 +58,99 @@
     z-index: 10;
 }
 
+.channel-diagram__wrapper {
+    width: 100%;
+    height: 100vh;
+    background: #f1f5f9;
+    display: flex;
+}
+
+.channel-diagram__layout {
+    display: flex;
+    flex: 1;
+    height: 100%;
+    position: relative;
+}
+
+.channel-diagram__canvas {
+    flex: 1;
+    position: relative;
+    min-width: 0;
+}
+
+.channel-diagram__flow {
+    width: 100%;
+    height: 100%;
+    background: #ffffff;
+}
+
+.channel-diagram__sidebar {
+    width: 360px;
+    max-width: 100%;
+    padding: 1.25rem;
+    background: #ffffff;
+    border-left: 1px solid #e2e8f0;
+    box-shadow: inset 8px 0 18px -18px rgba(15, 23, 42, 0.45);
+    overflow-y: auto;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.channel-diagram__sidebar-section {
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.05);
+}
+
+.channel-diagram__sidebar-title {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.channel-diagram__node-summary {
+    display: grid;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: #1f2937;
+}
+
+.channel-diagram__summary-label {
+    display: block;
+    font-weight: 600;
+    color: #334155;
+}
+
+.channel-diagram__summary-value {
+    margin-left: 0.35rem;
+    color: #0f172a;
+}
+
+.channel-diagram__sidebar-empty {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #475569;
+}
+
+@media (max-width: 1024px) {
+    .channel-diagram__layout {
+        flex-direction: column;
+    }
+
+    .channel-diagram__sidebar {
+        width: 100%;
+        border-left: none;
+        border-top: 1px solid #e2e8f0;
+        box-shadow: inset 0 8px 18px -18px rgba(15, 23, 42, 0.45);
+        max-height: 45vh;
+    }
+}
+
 .chd__sidebar {
     width: 320px;
     display: flex;

--- a/src/pages/ChannelDiagram/NodeEquipmentSidebar.jsx
+++ b/src/pages/ChannelDiagram/NodeEquipmentSidebar.jsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import api from "../../utils/api";
+import EquipoDetail from "../Equipment/EquipoDetail";
+import EquipoIrd from "../Equipment/EquipoIrd";
+
+const createEmptyState = () => ({ loading: false, data: null, error: null });
+
+const extractId = (value) => {
+  if (value == null) return null;
+  if (typeof value === "string" || typeof value === "number") {
+    const str = String(value).trim();
+    return str.length ? str : null;
+  }
+  if (typeof value === "object") {
+    const candidates = [value._id, value.id, value.value, value.key];
+    for (const candidate of candidates) {
+      if (candidate == null) continue;
+      const str = String(candidate).trim();
+      if (str.length) return str;
+    }
+  }
+  return null;
+};
+
+const NodeEquipmentSidebar = ({ node }) => {
+  const [equipoState, setEquipoState] = useState(() => createEmptyState());
+  const [irdState, setIrdState] = useState(() => createEmptyState());
+
+  const equipoId = useMemo(() => {
+    if (!node) return null;
+    const fromData = extractId(node?.data?.equipoId ?? node?.data?.equipo);
+    const fromRoot = extractId(node?.equipoId ?? node?.equipo);
+    return fromData ?? fromRoot ?? null;
+  }, [node]);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!equipoId) {
+      setEquipoState(createEmptyState());
+      setIrdState(createEmptyState());
+      return () => {
+        active = false;
+      };
+    }
+
+    setEquipoState({ loading: true, data: null, error: null });
+    setIrdState(createEmptyState());
+
+    api
+      .getIdEquipo(equipoId)
+      .then((res) => {
+        if (!active) return;
+        const data = res?.data ?? res;
+        setEquipoState({ loading: false, data, error: null });
+      })
+      .catch((err) => {
+        if (!active) return;
+        setEquipoState({
+          loading: false,
+          data: null,
+          error: err?.response?.data?.message || err?.message || "Error al cargar el equipo",
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [equipoId]);
+
+  useEffect(() => {
+    let active = true;
+
+    if (!node) {
+      setIrdState(createEmptyState());
+      return () => {
+        active = false;
+      };
+    }
+
+    const equipoData = equipoState.data;
+    const irdCandidate =
+      extractId(node?.data?.irdId ?? node?.data?.irdRef ?? node?.data?.ird) ??
+      extractId(equipoData?.irdRef ?? equipoData?.ird);
+
+    if (!irdCandidate) {
+      setIrdState(createEmptyState());
+      return () => {
+        active = false;
+      };
+    }
+
+    setIrdState({ loading: true, data: null, error: null });
+
+    api
+      .getIdIrd(irdCandidate)
+      .then((res) => {
+        if (!active) return;
+        const data = res?.data ?? res;
+        setIrdState({ loading: false, data, error: null });
+      })
+      .catch((err) => {
+        if (!active) return;
+        setIrdState({
+          loading: false,
+          data: null,
+          error: err?.response?.data?.message || err?.message || "Error al cargar el IRD",
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [node, equipoState.data]);
+
+  return (
+    <aside className="channel-diagram__sidebar">
+      <div className="channel-diagram__sidebar-section">
+        <h2 className="channel-diagram__sidebar-title">Detalle del nodo</h2>
+        {node ? (
+          <div className="channel-diagram__node-summary">
+            <div>
+              <span className="channel-diagram__summary-label">Nombre:</span>
+              <span className="channel-diagram__summary-value">{node?.data?.label || node?.label || node.id}</span>
+            </div>
+            <div>
+              <span className="channel-diagram__summary-label">ID nodo:</span>
+              <span className="channel-diagram__summary-value">{node?.id}</span>
+            </div>
+            <div>
+              <span className="channel-diagram__summary-label">Tipo:</span>
+              <span className="channel-diagram__summary-value">{node?.type || "custom"}</span>
+            </div>
+            <div>
+              <span className="channel-diagram__summary-label">Equipo asociado:</span>
+              <span className="channel-diagram__summary-value">{equipoId || "—"}</span>
+            </div>
+          </div>
+        ) : (
+          <p className="channel-diagram__sidebar-empty">Selecciona un nodo para consultar sus detalles.</p>
+        )}
+      </div>
+
+      {node && (
+        <div className="channel-diagram__sidebar-section">
+          <EquipoDetail
+            equipo={equipoState.data}
+            loading={equipoState.loading}
+            error={equipoState.error}
+            compact
+            title="Información del equipo"
+          />
+
+          <EquipoIrd
+            ird={irdState.data}
+            loading={irdState.loading}
+            error={irdState.error}
+            compact
+            title="Información IRD"
+          />
+        </div>
+      )}
+    </aside>
+  );
+};
+
+NodeEquipmentSidebar.propTypes = {
+  node: PropTypes.object,
+};
+
+export default NodeEquipmentSidebar;


### PR DESCRIPTION
## Summary
- add a reusable sidebar component that loads equipment and IRD information for the selected node
- update the ChannelDiagram view to manage node selection and render the sidebar next to the flow canvas
- extend ChannelDiagram styles to support the new right-hand layout and responsive behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ef6d82048321a29aa3957ba53876